### PR TITLE
bump stac browser version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
       browser_version_tag:
         description: 'browser version tag'
         required: true
-        default: v3.0.1
+        default: v3.0.2
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
3.0.1 -> 3.0.2

https://github.com/radiantearth/stac-browser/releases/tag/v3.0.2