### PR TITLE
Move deployment role and project name to secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-region: us-west-2
-        role-to-assume: arn:aws:iam::916098889494:role/GithubOIDCRole-MAAP-Project-maap-STAC-browser
+        role-to-assume: ${{ vars.DEPLOY_ROLE }}
         role-session-name: MAAPStacBrowserDeployment
 
     - name: Install deployment dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         aws-region: us-west-2
         role-to-assume: ${{ vars.DEPLOY_ROLE }}
-        role-session-name: MAAPStacBrowserDeployment
+        role-session-name: stac-browser-deployment
 
     - name: Install deployment dependencies
       run: npm install
@@ -72,6 +72,7 @@ jobs:
         STAGE: ${{ github.event.inputs.deployment_environment }}
         BROWSER_CLOUDFRONT_DISTRIBUTION_ARN: ${{ vars.BROWSER_CLOUDFRONT_DISTRIBUTION_ARN }}
         STAC_BROWSER_DIST_PATH: 'stac-browser/dist' 
+        PROJECT: ${{ vars.PROJECT }}
       run: |
         npm install -g aws-cdk
         cdk deploy --all --require-approval never

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MAAP STAC browser
+# STAC browser CDK
 
-This repository contains the AWS CDK code (written in typescript) used to deploy the STAC browser that acts as a front end to the MAAP STAC catalog. The app in itself is from https://github.com/radiantearth/stac-browser.
+This repository contains the AWS CDK code (written in typescript) used to deploy a STAC browser that acts as a front end to a MAAP STAC catalog. The app in itself is from https://github.com/radiantearth/stac-browser.
 
 ## Deployment
 

--- a/cdk/StacBrowser.ts
+++ b/cdk/StacBrowser.ts
@@ -12,24 +12,20 @@ export class StacBrowser extends Stack {
         const bucket = new s3.Bucket(this, 'Bucket', {
             accessControl: s3.BucketAccessControl.PRIVATE,
             removalPolicy: RemovalPolicy.DESTROY,
-            websiteIndexDocument: props.websiteIndexDocument,
             })
 
-        // If a cloudfront distribution is specified, grant it read access to the bucket
-        if (props.cloudFrontDistributionArn){
-            bucket.addToResourcePolicy(new PolicyStatement({
-                        sid: 'AllowCloudFrontServicePrincipal',
-                        effect: Effect.ALLOW, 
-                        actions: ['s3:GetObject'],
-                        principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
-                        resources: [bucket.arnForObjects('*')],
-                        conditions: {
-                            'StringEquals': {
-                                'aws:SourceArn': props.cloudFrontDistributionArn
-                            }
+        bucket.addToResourcePolicy(new PolicyStatement({
+                    sid: 'AllowCloudFrontServicePrincipal',
+                    effect: Effect.ALLOW, 
+                    actions: ['s3:GetObject'],
+                    principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
+                    resources: [bucket.arnForObjects('*')],
+                    conditions: {
+                        'StringEquals': {
+                            'aws:SourceArn': props.cloudFrontDistributionArn
                         }
-                    }));
-        }
+                    }
+                }));
         
 
         new s3_deployment.BucketDeployment(this, 'BucketDeployment', {
@@ -47,23 +43,11 @@ export class StacBrowser extends Stack {
 
 export interface Props extends StackProps {
 
-    
-    /** ARN of the cloudfront distribution to which we should grant read access to the browser bucket. If undefined,
-     * the policy is not modified.
-     * @default - No cloudfront distribution
-     */
-    cloudFrontDistributionArn?: string;
+    // ARN of the cloudfront distribution to which we should grant read access to the browser bucket. 
+    cloudFrontDistributionArn: string;
 
     // location of the stac-browser dist directory in the local filesystem
     stacBrowserDistPath: string;
-
-    /**
-     * The name of the index document (e.g. "index.html") for the website. Enables static website
-     * hosting for this bucket.
-     *
-     * @default - No index document.
-     */
-    websiteIndexDocument?: string;
 
 
 }

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -1,4 +1,5 @@
 export class Config {
+  readonly project: string | undefined;
   readonly stage: string;
   readonly browserCloudFrontDistrbutionArn: string;
   readonly stacBrowserDistPath: string;
@@ -10,6 +11,9 @@ export class Config {
     this.browserCloudFrontDistrbutionArn = process.env.BROWSER_CLOUDFRONT_DISTRIBUTION_ARN!;
     if (!process.env.STAC_BROWSER_DIST_PATH) throw Error("Must provide STAC_BROWSER_DIST_PATH");
     this.stacBrowserDistPath = process.env.STAC_BROWSER_DIST_PATH!;
+
+    this.project = process.env.PROJECT;
+     
   }
 
   /**
@@ -18,5 +22,5 @@ export class Config {
    * @returns Full id of stack
    */
   buildStackName = (serviceId: string): string =>
-    `MAAP-STAC-${this.stage}-${serviceId}`;
+    `${this.project}-STAC-${this.stage}-${serviceId}`;
 }


### PR DESCRIPTION
Making this repo reusable at least as a fork (for https://github.com/NASA-IMPACT/veda-architecture/issues/305)

- Move the deployment IAM role ARN to the secrets 
- Remove refs to "MAAP", ref to `props.PROJECT` instead, make `PROJECT` an env var (pulled from secrets in the workflow). 